### PR TITLE
ci: Add package build checks using scm versioning

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,68 @@
+name: publish distributions
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build-and-publish:
+    name: Build and publish Python distro to (Test)PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install pep517, check-manifest, and twine
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install pep517 --user
+        python -m pip install check-manifest twine
+    - name: Check MANIFEST
+      run: |
+        check-manifest
+    - name: Test the build backend is compliant with PEP517
+      run: |
+        python -m pep517.check .
+    - name: Build a wheel and a sdist
+      run: |
+        python -m pep517.build --source --binary --out-dir dist/ .
+    - name: Verify untagged commits have dev versions
+      if: "!startsWith(github.ref, 'refs/tags/')"
+      run: |
+        latest_tag=$(git describe --tags)
+        latest_tag_revlist_SHA=$(git rev-list -n 1 ${latest_tag})
+        master_SHA="$(git rev-parse --verify origin/master)"
+        wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
+        if [[ "${latest_tag_revlist_SHA}" != "${master_SHA}" ]]; then # don't check master push events coming from tags
+          if [[ "${wheel_name}" == *"heputils-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
+            echo "pep517.build incorrectly named built distribution: ${wheel_name}"
+            echo "pep517 is lacking the history and tags required to determine version number"
+            echo "intentionally erroring with 'return 1' now"
+            return 1
+          fi
+        else
+          echo "Push event to origin/master was triggered by push of tag ${latest_tag}"
+        fi
+        echo "pep517.build named built distribution: ${wheel_name}"
+    - name: Verify tagged commits don't have dev versions
+      if: startsWith(github.ref, 'refs/tags')
+      run: |
+        wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
+        if [[ "${wheel_name}" == *"dev"* ]]; then
+          echo "pep517.build incorrectly named built distribution: ${wheel_name}"
+          echo "this is incorrrectly being treated as a dev release"
+          echo "intentionally erroring with 'return 1' now"
+          return 1
+        fi
+        echo "pep517.build named built distribution: ${wheel_name}"
+    - name: Verify the distribution
+      run: twine check dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["wheel", "setuptools>=30.3.0", "attrs>=17.1", "setuptools_scm"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 88
 include = '\.pyi?$'

--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,7 @@ extras_require["develop"] = sorted(
 )
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))
 
-setup(extras_require=extras_require)
+setup(
+    extras_require=extras_require,
+    use_scm_version=lambda: {"local_scheme": lambda version: ""},
+)


### PR DESCRIPTION
Add GitHub Actions workflow to attempt verify that the library is able to be built into a distribution using a PEP517 build and verify that it it meets requirements for upload to PyPI.

```
* Add package publication build check GitHub Actions workflow
* Add build system requirements to pyproject.toml
   - Allows for PEP517 builds
* Use scm versioning to allow for dev releases to be tracked
```