### PR TITLE
feat: Add stack_hists API

### DIFF
--- a/src/heputils/convert.py
+++ b/src/heputils/convert.py
@@ -2,6 +2,8 @@
 
 import hist
 from hist import Hist
+import functools
+import operator
 
 
 def uproot_to_hist(uproot_hist):
@@ -64,3 +66,43 @@ def numpy_to_hist(values, edges, name=None):
     )
     _hist[:] = values
     return _hist
+
+
+def stack_hists(hists):
+    """
+    Create a stacked histogram from a list of `hist` histograms.
+
+    Example:
+
+        >>> import numpy as np
+        >>> import hist
+        >>> import heputils.convert as convert
+        >>> np.random.seed(0)
+        >>> h1 = hist.Hist(hist.axis.Regular(10, 0, 10), storage=hist.storage.Double())
+        >>> h2 = h1.copy()
+        >>> h1.fill(np.random.normal(loc=5, scale=1, size=100))
+        >>> h2.fill(np.random.normal(loc=6, scale=2, size=100))
+        >>> stack_hist = convert.stack_hists([h1, h2])
+        >>> print(stack_hist)
+                       +-------------------------------------------------------------+
+        [-inf,   0) 0  |                                                             |
+        [   0,   1) 0  |                                                             |
+        [   1,   2) 1  |=                                                            |
+        [   2,   3) 3  |===                                                          |
+        [   3,   4) 30 |===================================                          |
+        [   4,   5) 45 |====================================================         |
+        [   5,   6) 52 |============================================================ |
+        [   6,   7) 29 |=================================                            |
+        [   7,   8) 23 |===========================                                  |
+        [   8,   9) 6  |=======                                                      |
+        [   9,  10) 9  |==========                                                   |
+        [  10, inf) 2  |==                                                           |
+                       +-------------------------------------------------------------+
+
+    Args:
+        hists (`list`): A list of `hist` histograms
+
+    Returns:
+        hist.Hist.hist: The histogram that is the sum of the histograms in the list.
+    """
+    return functools.reduce(operator.add, hists)

--- a/src/heputils/convert.py
+++ b/src/heputils/convert.py
@@ -81,7 +81,9 @@ def stack_hists(hists):
         >>> h1 = hist.Hist(hist.axis.Regular(10, 0, 10), storage=hist.storage.Double())
         >>> h2 = h1.copy()
         >>> h1.fill(np.random.normal(loc=5, scale=1, size=100))
+        Hist(Regular(10, 0, 10, label='Axis 0'), storage=Double()) # Sum: 100.0
         >>> h2.fill(np.random.normal(loc=6, scale=2, size=100))
+        Hist(Regular(10, 0, 10, label='Axis 0'), storage=Double()) # Sum: 98.0 (100.0 with flow)
         >>> stack_hist = convert.stack_hists([h1, h2])
         >>> print(stack_hist)
                        +-------------------------------------------------------------+

--- a/src/heputils/convert.py
+++ b/src/heputils/convert.py
@@ -29,7 +29,7 @@ def uproot_to_hist(uproot_hist):
     # c.f. https://github.com/scikit-hep/hist/issues/115
     # return uproot_hist.to_hist()
     values, edges = uproot_hist.to_numpy()
-    return numpy_to_hist(values, edges, name=uproot_hist.all_members["fName"])
+    return numpy_to_hist(values, edges)
 
 
 def uproot_to_numpy(uproot_hist):


### PR DESCRIPTION
```
* Remove metadata from convert.uproot_to_hist to avoid error
   - Incompatible metadata of any sort results in ValueError: axes not mergable
* Add convert.stack_hists API to create stacked histograms from list
```

Thanks to @henryiii for his help on this in the HSF/PyHEP-histogramming Gitter channel.