### PR TITLE
fix: Add sans-serif Font family expected by mplhep ATLAS style for Binder

### DIFF
--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,0 +1,1 @@
+fonts-open-sans

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,2 +1,3 @@
 msttcorefonts
 ttf-mscorefonts-installer
+fonts-freefont-ttf

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,3 +1,1 @@
-msttcorefonts
-ttf-mscorefonts-installer
 fonts-freefont-ttf

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,2 +1,1 @@
-fonts-open-sans
-msttcorefonts
+ttf-mscorefonts-installer

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,1 +1,2 @@
 fonts-open-sans
+msttcorefonts

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,1 +1,2 @@
+msttcorefonts
 ttf-mscorefonts-installer

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,4 +1,6 @@
 python -m pip install --upgrade .[lint]
+apt-get update -y
+apt-get install -y fonts-open-sans
 # Create example JSON
 python tests/example_files.py
 mv example.root examples/example.root

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,5 +1,4 @@
 python -m pip install --upgrade .
-rm ~/.cache/matplotlib -rf
 # Create example JSON
 python tests/example_files.py
 mv example.root examples/example.root

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,4 +1,5 @@
-python -m pip install --upgrade .[lint]
+python -m pip install --upgrade .
+rm ~/.cache/matplotlib -rf
 # Create example JSON
 python tests/example_files.py
 mv example.root examples/example.root

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,6 +1,4 @@
 python -m pip install --upgrade .[lint]
-apt-get update -y
-apt-get install -y fonts-open-sans
 # Create example JSON
 python tests/example_files.py
 mv example.root examples/example.root


### PR DESCRIPTION
If no additional fonts are installed beyond what Ubuntu has, then `mplhep` will cause `matplotlib` to complain when `mplhep.set_style("ATLAS")` is used with the following warning

```
findfont: Font family ['sans-serif'] not found. Falling back to DejaVu Sans.
```

This is happening because [`mplhep`'s ATLAS style defines the following fonts](https://github.com/scikit-hep/mplhep/blob/1fde65b35f81a3ff01d6636339f7d20f951ed535/src/mplhep/styles/atlas.py#L7-L13) as being acceptable to use for the `sans-serif` font family

```python
    "font.family": "sans-serif",
    "font.sans-serif": [
        "helvetica",
        "Helvetica",
        "Nimbus Sans L",
        "Mukti Narrow",
        "FreeSans",
    ],
```

Without installing additional fonts, none of these fonts exist on the default Binder Docker image (Ubuntu based). As a result, at least one of them needs to be installed, and FeeSans can be installed with the `fonts-freefont-ttf` package.

This is similar in resolution as to the "fix" for https://github.com/scikit-hep/mplhep/issues/178.


```
* Have Binder install the fonts-freefont-ttf package to get FreeSans font
   - Expected by mplhep ATLAS style
   - Avoid "findfont: Font family ['sans-serif'] not found. Falling back to DejaVu Sans." warning in Binder
* Don't install lint extra in postBuild of Binder
```