### PR TITLE
fix: Remove flake8 F401, F403 from ignores

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203, E266, E501, W503, F403, F401
+ignore = E203, E266, E501, W503, F403
 max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203, E266, E501, W503, F403
+ignore = E203, E266, E501, W503
 max-line-length = 88
 max-complexity = 18
 select = B,C,E,F,W,T4,B9


### PR DESCRIPTION
```
* Remove flake8 F401 and F403 from ignores in .flake8
   - F401: module imported but unused
   - F403: ‘from module import *’ used; unable to detect undefined names
```

Thanks to @kratsg for the catch.

