### PR TITLE
ci: Publish releases to TestPyPI and PyPI

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,11 +3,12 @@ on:
   push:
     branches:
     - master
-    tags:
-    - v*
   pull_request:
     branches:
     - master
+  release:
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   build-and-publish:
@@ -28,37 +29,30 @@ jobs:
     - name: Check MANIFEST
       run: |
         check-manifest
-    - name: Build a wheel and a sdist
+    - name: Build a binary wheel and a source tarball
       run: |
         python -m build --sdist --wheel --outdir dist/ .
-    - name: Verify untagged commits have dev versions
-      if: "!startsWith(github.ref, 'refs/tags/')"
-      run: |
-        latest_tag=$(git describe --tags)
-        latest_tag_revlist_SHA=$(git rev-list -n 1 ${latest_tag})
-        master_SHA="$(git rev-parse --verify origin/master)"
-        wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
-        if [[ "${latest_tag_revlist_SHA}" != "${master_SHA}" ]]; then # don't check master push events coming from tags
-          if [[ "${wheel_name}" == *"heputils-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
-            echo "python-build incorrectly named built distribution: ${wheel_name}"
-            echo "python-build is lacking the history and tags required to determine version number"
-            echo "intentionally erroring with 'return 1' now"
-            return 1
-          fi
-        else
-          echo "Push event to origin/master was triggered by push of tag ${latest_tag}"
-        fi
-        echo "python-build named built distribution: ${wheel_name}"
-    - name: Verify tagged commits don't have dev versions
-      if: startsWith(github.ref, 'refs/tags')
+    - name: Verify history available for dev versions
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
-        if [[ "${wheel_name}" == *"dev"* ]]; then
+        if [[ "${wheel_name}" == *"heputils-0.1.dev"* ]]; then
           echo "python-build incorrectly named built distribution: ${wheel_name}"
-          echo "this is incorrrectly being treated as a dev release"
+          echo "python-build is lacking the history and tags required to determine version number"
           echo "intentionally erroring with 'return 1' now"
           return 1
         fi
         echo "python-build named built distribution: ${wheel_name}"
     - name: Verify the distribution
       run: twine check dist/*
+    - name: Publish distribution 📦 to Test PyPI
+      # every PR will trigger a push event on master, so check the push event is actually coming from master
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'matthewfeickert/heputils'
+      uses: pypa/gh-action-pypi-publish@v1.4.1
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution 📦 to PyPI
+      if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'matthewfeickert/heputils'
+      uses: pypa/gh-action-pypi-publish@v1.4.1
+      with:
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Check MANIFEST
       run: |
         check-manifest
-    - name: Build a binary wheel and a source tarball
+    - name: Build a wheel and a sdist
       run: |
         python -m build --sdist --wheel --outdir dist/ .
     - name: Verify history available for dev versions

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/heputils/HEAD?urlpath=lab/tree/examples/dev-example.ipynb)
 
+[![PyPI version](https://badge.fury.io/py/heputils.svg)](https://badge.fury.io/py/heputils)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/heputils.svg)](https://pypi.org/project/heputils/)
+
 Helper utilities around the [Scikit-HEP ecosystem][Scikit-HEP] for common tasks in HEP
 
 **This library is not meant for wide use and will probably be deprecated in favor of a Scikit-HEP library soon.**

--- a/README.md
+++ b/README.md
@@ -10,17 +10,16 @@
 Helper utilities around the [Scikit-HEP ecosystem][Scikit-HEP] for common tasks in HEP
 
 **This library is not meant for wide use and will probably be deprecated in favor of a Scikit-HEP library soon.**
-This library should be viewed as a testing grounds for API design decisions, hence it will not be put up on PyPI.
+This library should be viewed as a testing grounds for API design decisions.
 
 ## Installation
 
 In a fresh virtual environment
 
 ```
-$ python -m pip install "git+https://github.com/matthewfeickert/heputils.git"
+$ python -m pip install heputils
 ```
 
-The above is actually cloning and installing directly from the Git repository.
 However, if you want to, you can of course also install it directly from the Git repository "locally" by first cloning the repo and then from the top level of it running
 
 ```


### PR DESCRIPTION
For publishing to PyPI

- Locally on `master` run:

```
$ git checkout master && git pull # verify that you're on master and synced with GitHub
$ bump2version <part> # bump the version and create a commit and tag
$ git push origin master --tags # push the commit and the tag to GitHub, causing TestPyPI to publish
```
- Then on GitHub:
   1. Go to releases: https://github.com/matthewfeickert/heputils/releases
   2. Click "Draft a new release"
   3. On the new page enter the tag you just pushed (e.g. `v0.1.0`) in the "Tag version" box and the "Release title" box (to make it easy unless you really want to get descriptive)
   4. Enter any release notes and click "Publish release"
- This then kicks of the publication CD workflow that will use the PyPI API key to publish.

```
* Publish to TestPyPI on every merged PR
* Publish to PyPI through published release events triggered through GitHub releases
   - c.f. https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#release
```