### PR TITLE
fix: Direct bump2version to setup.cfg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,6 +3,6 @@ current_version = 0.0.1
 commit = True
 tag = True
 
-[bumpversion:file:setup.py]
+[bumpversion:file:setup.cfg]
 
 [bumpversion:file:src/heputils/version.py]


### PR DESCRIPTION
```
* Have bump2verison look for version info in setup.cfg and not setup.py
```