### PR TITLE
feat: Add histstyle kwarg to plot.shape_hist

### DIFF
--- a/examples/dev-example.ipynb
+++ b/examples/dev-example.ipynb
@@ -168,6 +168,46 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For a shape plot you can also easily switch between a `fill` style (shaded) and a `step` style (lines) using the `histtype` kwarg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_fig_size = heputils.plot.get_style()[\"figure.figsize\"]\n",
+    "fig, axs = plt.subplots(1, 2, figsize=(2.1 * _fig_size[0], _fig_size[1]))\n",
+    "\n",
+    "axs[0] = heputils.plot.shape_hist(\n",
+    "    simulation_hists,\n",
+    "    data_hist=data_hist,\n",
+    "    labels=labels,\n",
+    "    color=colormap,\n",
+    "    histtype=\"step\",\n",
+    "    xlabel=r\"$X$ Mass [GeV]\",\n",
+    "    ylabel=\"Count\",\n",
+    "    ax=axs[0],\n",
+    ")\n",
+    "axs[1] = heputils.plot.shape_hist(\n",
+    "    simulation_hists,\n",
+    "    data_hist=data_hist,\n",
+    "    labels=labels,\n",
+    "    color=colormap,\n",
+    "    histtype=\"step\",\n",
+    "    xlabel=r\"$X$ Mass [GeV]\",\n",
+    "    ylabel=\"Count\",\n",
+    "    logy=True,\n",
+    "    density=False,\n",
+    "    ax=axs[1],\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/src/heputils/plot.py
+++ b/src/heputils/plot.py
@@ -185,12 +185,17 @@ def shape_hist(hists, ax=None, **kwargs):
     if color is not None:
         if len(color) != len(hists):
             color = color[: len(hists)]
-    alpha = kwargs.pop("alpha", 0.1)
     semilogy = kwargs.pop("logy", False)
     _data_hist = kwargs.pop("data_hist", None)
     data_uncert = kwargs.pop("data_uncert", None)
     data_label = kwargs.pop("data_label", "Data")
     density = kwargs.pop("density", True)
+    histtype = kwargs.pop("histtype", "fill")
+    if histtype == "fill":
+        _default_alpha = 0.1
+    else:
+        _default_alpha = None
+    alpha = kwargs.pop("alpha", _default_alpha)
 
     if ax is None:
         ax = plt.gca()
@@ -198,7 +203,7 @@ def shape_hist(hists, ax=None, **kwargs):
     histplot(
         hists,
         stack=False,
-        histtype="fill",
+        histtype=histtype,
         density=density,
         label=labels,
         color=color,


### PR DESCRIPTION
Resolves #25 

Add `histstyle` kwarg to enable setting `step` as the `histstyle` for `mplhep`. Still default to `fill` as default style.

```
* Add histstyle kwarg to allow for 'step' style (lines)
* Add example of using 'step' style to example notebook
```