### PR TITLE
fix: Use uproot3 namespace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     hooks:
     - id: pyupgrade
 -   repo: https://github.com/nbQA-dev/nbQA
-    rev: 0.5.1
+    rev: 0.5.2
     hooks:
     - id: nbqa-black
       additional_dependencies: [black==20.8b1]

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     awkward1>=0.2
     uproot4>=0.1.0
     hist[plot]>=2.0.1
-    uproot>=3.0 # Needed until writing added in uproot4
+    uproot3>=3.14 # Needed until writing added in uproot4
 
 [options.packages.find]
 where = src

--- a/tests/example_files.py
+++ b/tests/example_files.py
@@ -1,6 +1,6 @@
 import numpy as np
 import json
-import uproot as uproot3
+import uproot3
 
 _bins = np.arange(0, 10200, 200).tolist()
 


### PR DESCRIPTION
```
* Require uproot3 library explicitly
   - Use uproot3 over uproot~=3.0 to ensure correct namespaces for uproot-methods
* Use uproot3 namespace
* Update nbQA to v0.5.2
```