### PR TITLE
docs: Update dev release install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,13 @@ python -m pip install heputils
 ### Development releases
 
 If you want to install _unsupported_ development releases you can do so from TestPyPI.
-First install the library like normal from PyPI to get stable releases of all dependencies
+**First** install `heputils` like normal from PyPI to get stable releases of all dependencies
 
 ```
 python -m pip install heputils
 ```
 
-**then** install the development release of `heputils` from TestPyPI
-with the following
+**then** install the development release of `heputils` from TestPyPI with the following
 
 ```
 python -m pip install --upgrade --extra-index-url https://test.pypi.org/simple/ --pre heputils

--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ python -m pip install heputils
 
 ### Development releases
 
-If you want to install _unsupported_ development releases you can do so from TestPyPI with the following
+If you want to install _unsupported_ development releases you can do so from TestPyPI.
+First install the library like normal from PyPI to get stable releases of all dependencies
+
+```
+python -m pip install heputils
+```
+
+**then** install the development release of `heputils` from TestPyPI
+with the following
 
 ```
 python -m pip install --upgrade --extra-index-url https://test.pypi.org/simple/ --pre heputils


### PR DESCRIPTION
Note that users should first install from PyPI to get stable releases of all dependencies.


```
* Add instructions to install from PyPI first to get stable releases of all dependencies
```