### PR TITLE
fix: Update docstrings to use new ATLAS style figure size

### DIFF
--- a/src/heputils/plot.py
+++ b/src/heputils/plot.py
@@ -49,7 +49,7 @@ def get_style(style=None):
         >>> import heputils
         >>> heputils.plot.set_style("ATLAS")
         >>> heputils.plot.get_style()["figure.figsize"]
-        [8.75, 5.92]
+        [8.0, 6.0]
         >>> heputils.plot.get_style("CMS")["figure.figsize"]
         (10.0, 10.0)
 


### PR DESCRIPTION
In https://github.com/scikit-hep/mplhep/pull/239 the default size for ATLAS style figures was updated and this change was released in `mplhep` `v0.2.10`, so the docstrings need to be as well to pass `doctest`.

```
* Update docstrings to use ATLAS figure size from mplhep v0.2.10
   - c.f. https://github.com/scikit-hep/mplhep/pull/239
```