### PR TITLE
feat: Add Felipa font to Binder to provide matplotlib cursive font family font

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,3 +1,12 @@
+# Ensure matplotlib has font from cursive font family
+# https://stackoverflow.com/q/65649122/8931942
+if [ ! -d "${HOME}/.local/share/fonts/truetype/felipa" ]; then
+    mkdir -p "${HOME}/.local/share/fonts/truetype/felipa"
+    wget --no-clobber https://github.com/google/fonts/blob/master/ofl/felipa/Felipa-Regular.ttf?raw=true -O "${HOME}/.local/share/fonts/truetype/felipa/Felipa-Regular.ttf"
+    fc-cache --force --verbose # force system font cache rebuild
+fi
+
+# Install library
 python -m pip install --upgrade .
 # Create example JSON
 python tests/example_files.py

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -8,6 +8,7 @@ fi
 
 # Install library
 python -m pip install --upgrade .
+
 # Create example JSON
 python tests/example_files.py
 mv example.root examples/example.root


### PR DESCRIPTION
As discussed in the Stack Overflow question "[How to install cursive fonts for matplotlib: Font family ['cursive'] not found](https://stackoverflow.com/q/65649122/8931942)", there is currently no Ubuntu PPA that includes any of the fonts that are in the default matplotlib cursive font family, which results in warnings when cursive fonts are used. To avoid this, download the [Felipa font from Goolgle Fonts](https://fonts.google.com/specimen/Felipa?query=Felipa) and make it findable so that it can be used without throwing warnings.

```
* Add download of Felipa font to postBuild
   - Provides Binder with cursive font that is part of the matplotlib cursive font family
   - c.f. https://stackoverflow.com/q/65649122/8931942
```