### PR TITLE
chore: Update namespaces for uproot v4.0 and awkward v1.0

### DIFF
--- a/examples/dev-example.ipynb
+++ b/examples/dev-example.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import uproot4 as uproot\n",
+    "import uproot\n",
     "import matplotlib.pyplot as plt\n",
     "import heputils\n",
     "\n",
@@ -250,7 +250,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ include_package_data = True
 python_requires = >=3.6
 install_requires =
     click>=6.0
-    awkward1>=0.2
+    awkward~=1.0
     uproot~=4.0
     hist[plot]>=2.0.1
     uproot3>=3.14 # Needed until writing added in uproot4

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ python_requires = >=3.6
 install_requires =
     click>=6.0
     awkward1>=0.2
-    uproot4>=0.1.0
+    uproot~=4.0
     hist[plot]>=2.0.1
     uproot3>=3.14 # Needed until writing added in uproot4
 

--- a/src/heputils/convert.py
+++ b/src/heputils/convert.py
@@ -10,11 +10,11 @@ def uproot_to_hist(uproot_hist):
 
     Example:
 
-        >>> import uproot4 as uproot
+        >>> import uproot
         >>> import heputils.convert as convert
         >>> root_file = uproot.open("example.root") # doctest: +SKIP
         >>> type(root_file["jet_mass"]) # doctest: +SKIP
-        uproot4.dynamic.Model_TH1F_v3
+        uproot.dynamic.Model_TH1F_v3
         >>> hist_jet_mass = convert.uproot_to_hist(root_file["jet_mass"]) # doctest: +SKIP
         >>> type(hist_jet_mass) # doctest: +SKIP
         <class 'hist.hist.Hist'>


### PR DESCRIPTION
Update namespaces from `uproot4` to `uproot` and `awkward1` to `awkward` following their respective releases.

```
* Update namespace from uproot4 to uproot
* Update namespace from awkward1 to awkward
* Require compatible releases with uproot v4.0 and awkward v1.0
```