### PR TITLE
build: Remove universal wheel flag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ classifiers =
     Programming Language :: Python :: 3.9
 
 [bdist_wheel]
-universal = 1
 
 [options]
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,6 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
 
-[bdist_wheel]
-
 [options]
 setup_requires =
     setuptools_scm>=1.15.0


### PR DESCRIPTION
For posterity (and self reference), in the [PyPA's "Packaging and distributing projects" guide the section on wheels](https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels) notes that

> Only use the `--universal setting`, if:
>
> 1. Your project runs on Python 2 and 3 with no changes (i.e. it does not require 2to3).
> 2. Your project does not have any C extensions.

```
* Remove universal wheel setting as pylhe is Python 3 only
   - Fixes py2.py3 tag naming scheme for wheels
```