### PR TITLE
fix: Ensure uncertainty bars don't extend below 0 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# text editor configs
+.vscode/

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     click>=6.0
     awkward~=1.0
     uproot~=4.0
-    hist[plot]>=2.0.1
+    hist[plot]>=2.2.0
     uproot3>=3.14 # Needed until writing added in uproot4
 
 [options.packages.find]

--- a/src/heputils/plot.py
+++ b/src/heputils/plot.py
@@ -294,13 +294,16 @@ def _plot_uncertainty(model_hist, ax):
     stat_uncert = np.sqrt(model_hist)
     bin_centers = model_hist.axes.centers[0]
     bin_widths = model_hist.axes.widths[0]
+    bar_bottom = model_hist - stat_uncert
+    # Ensure uncertainties don't extend below 0
+    bar_bottom[bar_bottom < 0] = 0
     uncert_label = "Stat Uncertainty"
 
     ax.bar(
         bin_centers,
         height=2 * stat_uncert,
         width=bin_widths,
-        bottom=model_hist - stat_uncert,
+        bottom=bar_bottom,
         fill=False,
         linewidth=0,
         edgecolor="gray",

--- a/src/heputils/plot.py
+++ b/src/heputils/plot.py
@@ -394,6 +394,7 @@ def shape_hist(hists, ax=None, **kwargs):
         stack=False,
         histtype=histtype,
         density=density,
+        yerr=False,
         label=labels,
         color=color,
         alpha=alpha,

--- a/tests/example_files.py
+++ b/tests/example_files.py
@@ -228,7 +228,7 @@ hists["signal"] = {
 
 
 def make_data_hist(hists):
-    # Make pseudodata from Poisson fluctuaions
+    # Make pseudodata from Poisson fluctuations
     data_hist = []
     for key in hists.keys():
         counts = np.array(hists[key]["counts"])

--- a/tests/example_files.py
+++ b/tests/example_files.py
@@ -2,7 +2,7 @@ import numpy as np
 import json
 import uproot3
 
-_bins = np.arange(0, 10200, 200).tolist()
+_bins = np.arange(0, 1020, 20).tolist()
 
 hists = {}
 hists["ttbar"] = {


### PR DESCRIPTION
Resolves #41 

```
* Ensure the bottom of uncertainty bars don't extend below 0
   - Avoid axis limits dropping below 0
* Rebin example histograms
   - Avoid running into range limitations of ATLAS Style
* Set lower bound on hist to v2.2.0
   - Pickup boost-histogram v1.0 and mplhep v0.2.16+
* Add VS Code settings to gitignore
```

Huge thanks goes out to @henryiii and @andrzejnovak for their impressive work on `hist` and `mplhep`!