### PR TITLE
build: Set only lower bounds on core dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ include_package_data = True
 python_requires = >=3.6
 install_requires =
     click>=6.0
-    awkward~=1.0
+    awkward>=1.0
     uproot>=4.0
     hist[plot]>=2.2.0
     uproot3>=3.14 # Needed until writing added in uproot4

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ python_requires = >=3.6
 install_requires =
     click>=6.0
     awkward~=1.0
-    uproot~=4.0
+    uproot>=4.0
     hist[plot]>=2.2.0
     uproot3>=3.14 # Needed until writing added in uproot4
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,10 +48,3 @@ where = src
 [options.entry_points]
 console_scripts =
     heputils = heputils.cli:cli
-
-[build_sphinx]
-project = heputils
-source-dir = docs
-build-dir = docs/_build
-all-files = 1
-warning-is-error = 1


### PR DESCRIPTION
Take [Henry and Hynek's advice](https://twitter.com/HEPfeickert/status/1366801537499099139?s=20) and set lower bounds only on core dependencies

```
* Set only lower bounds on awkward and uproot
   - c.f. https://hynek.me/articles/semver-will-not-save-you/
* Remove unused Sphinx build options in setup.cfg
```