### PR TITLE
ci: Update PyPI publish GHA to v1.4.2

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on main, so check the push event is actually coming from main
       if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'matthewfeickert/heputils'
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -53,6 +53,6 @@ jobs:
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'matthewfeickert/heputils'
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
```
* Update pypa/gh-action-pypi-publish GitHub Action to v1.4.2
   - c.f. https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.4.2
```