### PR TITLE
fix: Use `mplhep.style.use` to set style in `set_style`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,31 +20,31 @@ repos:
     - id: trailing-whitespace
 
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.20.0
+    rev: v2.23.1
     hooks:
     - id: pyupgrade
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.9.1
+    rev: 5.9.3
     hooks:
     - id: isort
+
+-   repo: https://github.com/psf/black
+    rev: 21.7b0
+    hooks:
+    - id: black
 
 -   repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
     - id: flake8
 
--   repo: https://github.com/psf/black
-    rev: 21.6b0
-    hooks:
-    - id: black
-
 -   repo: https://github.com/nbQA-dev/nbQA
-    rev: 0.13.1
+    rev: 1.0.0
     hooks:
     - id: nbqa-pyupgrade
-      additional_dependencies: [pyupgrade==2.20.0]
+      additional_dependencies: [pyupgrade==2.23.1]
     - id: nbqa-isort
-      additional_dependencies: [isort==5.9.1]
+      additional_dependencies: [isort==5.9.3]
     - id: nbqa-black
-      additional_dependencies: [black==21.6b0]
+      additional_dependencies: [black==21.7b0]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
     rev: v2.23.1
     hooks:
     - id: pyupgrade
+      args: ["--py37-plus"]
 
 -   repo: https://github.com/pycqa/isort
     rev: 5.9.3

--- a/src/heputils/plot.py
+++ b/src/heputils/plot.py
@@ -36,7 +36,7 @@ def set_style(style):
     Args:
         style (str or `mplhep.style` dict): The experiment style
     """
-    mplhep.set_style(style)
+    mplhep.style.use(style)
     set_experiment_info(reset=True)
     if isinstance(style, str):
         set_experiment_info(name=style.lower())

--- a/src/heputils/plot.py
+++ b/src/heputils/plot.py
@@ -42,6 +42,23 @@ def set_style(style):
         set_experiment_info(name=style.lower())
 
 
+def use(style):
+    """
+    Alias for ``heputils.plot.set_style`` to match ``mplhep``'s API.
+
+    Example:
+
+        >>> import heputils
+        >>> import mplhep
+        >>> heputils.plot.use("ATLAS")
+        >>> heputils.plot.use(mplhep.style.CMS)
+
+    Args:
+        style (str or ``mplhep.style`` dict): The experiment style
+    """
+    set_style(style)
+
+
 def get_style(style=None):
     """
     Set the experiment specific plotting style


### PR DESCRIPTION
Resolves #69

```
* Internally use `mplhep.style.use` API over deprecated `mplhep.set_style`
* Add `heputils.plot.use` alias for `heputils.plot.set_style` to match mplhep API
* Update pre-commit hooks
```