### PR TITLE
refactor: Use absolute imports

### DIFF
--- a/src/heputils/__init__.py
+++ b/src/heputils/__init__.py
@@ -1,7 +1,7 @@
-from . import convert
-from . import plot
-from . import utils
-from .version import __version__
+from heputils import convert
+from heputils import plot
+from heputils import utils
+from heputils.version import __version__
 
 # Satisfy pyflakes
 __all__ = ["__version__", "plot", "convert", "utils"]

--- a/src/heputils/cli/__init__.py
+++ b/src/heputils/cli/__init__.py
@@ -1,4 +1,4 @@
 """The heputils command line interface."""
-from .cli import heputils as cli
+from heputils.cli import heputils as cli
 
 __all__ = ["cli"]

--- a/src/heputils/cli/__init__.py
+++ b/src/heputils/cli/__init__.py
@@ -1,4 +1,4 @@
 """The heputils command line interface."""
-from heputils.cli import heputils as cli
+from heputils.cli.cli import heputils as cli
 
 __all__ = ["cli"]

--- a/src/heputils/cli/cli.py
+++ b/src/heputils/cli/cli.py
@@ -2,7 +2,7 @@ import logging
 
 import click
 
-from ..version import __version__
+from heputils.version import __version__
 
 logging.basicConfig()
 log = logging.getLogger(__name__)

--- a/src/heputils/plot.py
+++ b/src/heputils/plot.py
@@ -7,7 +7,7 @@ import mplhep
 import numpy as np
 from mplhep import histplot
 
-from . import utils
+from heputils import utils
 
 # To be able to reset
 _experiment_label_info_defaults = {


### PR DESCRIPTION
```
* Use absolute imports over relative imports to avoid circular imports
```