### PR TITLE
build: Revise MANIFEST.in strategy to properly use prune

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Build a wheel and a sdist
       run: |
-        python -m build --sdist --wheel --outdir dist/ .
+        python -m build --outdir dist/ .
 
     - name: Verify history available for dev versions
       run: |
@@ -51,6 +51,9 @@ jobs:
 
     - name: Verify the distribution
       run: twine check dist/*
+
+    - name: List contents of sdist
+      run: tar --list --file dist/pyhf-*.tar.gz
 
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on main, so check the push event is actually coming from main

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,23 +15,29 @@ jobs:
     name: Build and publish Python distro to (Test)PyPI
     runs-on: ubuntu-latest
     steps:
+
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+
     - name: Install python-build, check-manifest, and twine
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install build check-manifest twine
+
     - name: Check MANIFEST
       run: |
         check-manifest
+
     - name: Build a wheel and a sdist
       run: |
         python -m build --sdist --wheel --outdir dist/ .
+
     - name: Verify history available for dev versions
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
@@ -42,8 +48,10 @@ jobs:
           return 1
         fi
         echo "python-build named built distribution: ${wheel_name}"
+
     - name: Verify the distribution
       run: twine check dist/*
+
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on main, so check the push event is actually coming from main
       if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'matthewfeickert/heputils'
@@ -51,6 +59,7 @@ jobs:
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
+
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'matthewfeickert/heputils'
       uses: pypa/gh-action-pypi-publish@v1.4.2

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -53,7 +53,7 @@ jobs:
       run: twine check dist/*
 
     - name: List contents of sdist
-      run: tar --list --file dist/pyhf-*.tar.gz
+      run: tar --list --file dist/heputils-*.tar.gz
 
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on main, so check the push event is actually coming from main

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,12 @@
+prune **
 graft src
 
+include setup.py
+include setup.cfg
 include LICENSE
+include README.rst
+include pyproject.toml
+include MANIFEST.in
+include AUTHORS
 
 global-exclude __pycache__ *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,9 +4,8 @@ graft src
 include setup.py
 include setup.cfg
 include LICENSE
-include README.rst
+include README.md
 include pyproject.toml
 include MANIFEST.in
-include AUTHORS
 
 global-exclude __pycache__ *.py[cod]


### PR DESCRIPTION
Resolves #73 

Copy of https://github.com/scikit-hep/pyhf/pull/1449

```
* Remove global exclude of dotfiles from MANIFEST.in to avoid potential problems with build systems
   - c.f. https://github.com/scikit-build/scikit-build/issues/537
* Use `prune **` to remove all files from the sdist
   - c.f. https://packaging.python.org/guides/using-manifest-in/#manifest-in-commands
   - "Setuptools also has undocumented support for ** matching zero or more characters including forward slash, backslash, and colon."
* Manually include all "default" files for a sdist in MANIFEST.in
   - c.f. https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist
* Add list of sdist contents to package publishing CI
   - Allow for easier checking of the sdist contents in CI logs
```