### PR TITLE
fix: Ensure that xlabel is passed through with ax

### DIFF
--- a/src/heputils/plot.py
+++ b/src/heputils/plot.py
@@ -348,6 +348,7 @@ def data_hist(hist, uncert=None, ax=None, **kwargs):
 
     # get all the kwargs
     if ax and not kwargs.get("xlabel"):
+        # Set from ax to avoid having hist.ax[0].label overwrite in histoplot
         kwargs["xlabel"] = ax.get_xlabel()
     color = kwargs.pop("color", "black")
     label = kwargs.pop("label", "Data")

--- a/src/heputils/plot.py
+++ b/src/heputils/plot.py
@@ -345,11 +345,11 @@ def data_hist(hist, uncert=None, ax=None, **kwargs):
         uncert = np.sqrt(hist.values())
     if ax is None:
         ax = plt.gca()
-
-    # get all the kwargs
-    if ax and not kwargs.get("xlabel"):
+    elif not kwargs.get("xlabel"):
         # Set from ax to avoid having hist.ax[0].label overwrite in histoplot
         kwargs["xlabel"] = ax.get_xlabel()
+
+    # get all the kwargs
     color = kwargs.pop("color", "black")
     label = kwargs.pop("label", "Data")
     density = kwargs.pop("density", False)
@@ -403,6 +403,9 @@ def shape_hist(hists, ax=None, **kwargs):
 
     if ax is None:
         ax = plt.gca()
+    elif not kwargs.get("xlabel"):
+        # Set from ax to avoid having hists[0].ax[0].label overwrite in histoplot
+        kwargs["xlabel"] = ax.get_xlabel()
 
     histplot(
         hists,
@@ -470,6 +473,9 @@ def stack_hist(hists, ax=None, **kwargs):
 
     if ax is None:
         ax = plt.gca()
+    elif not kwargs.get("xlabel"):
+        # Set from ax to avoid having hists[0].ax[0].label overwrite in histoplot
+        kwargs["xlabel"] = ax.get_xlabel()
 
     if all(v is not None for v in [labels, scale_factors]):
         labels = [

--- a/src/heputils/plot.py
+++ b/src/heputils/plot.py
@@ -347,6 +347,8 @@ def data_hist(hist, uncert=None, ax=None, **kwargs):
         ax = plt.gca()
 
     # get all the kwargs
+    if ax and not kwargs.get("xlabel"):
+        kwargs["xlabel"] = ax.get_xlabel()
     color = kwargs.pop("color", "black")
     label = kwargs.pop("label", "Data")
     density = kwargs.pop("density", False)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -5,11 +5,10 @@ from hist import Hist
 
 import heputils
 
-heputils.plot.set_style("ATLAS")
-
 
 def test_xlabel_passed_through_ax():
     np.random.seed(0)
+    heputils.plot.set_style("ATLAS")
 
     hist_1 = Hist(
         hist.axis.Regular(

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,0 +1,46 @@
+import hist
+
+# from matplotlib.figure import Figure
+import matplotlib.pyplot as plt
+import numpy as np
+from hist import Hist
+
+import heputils
+
+heputils.plot.set_style("ATLAS")
+
+
+def test_xlabel_passed_through_ax():
+    np.random.seed(0)
+
+    hist_1 = Hist(
+        hist.axis.Regular(
+            50, -5, 5, name="x", label="x [units]", underflow=False, overflow=False
+        ),
+        storage=hist.storage.Weight(),
+    ).fill(np.random.normal(size=1000), weight=1.0)
+    hist_2 = Hist(
+        hist.axis.Regular(
+            50, -5, 5, name="x", label="x [units]", underflow=False, overflow=False
+        ),
+        storage=hist.storage.Weight(),
+    ).fill(np.random.normal(size=1000), weight=1.0)
+    hist_3 = Hist(
+        hist.axis.Regular(
+            50, -5, 5, name="x", label="x [units]", underflow=False, overflow=False
+        ),
+        storage=hist.storage.Weight(),
+    ).fill(np.random.normal(size=1000), weight=1.0)
+
+    hists = [hist_1, hist_2]
+
+    fig, ax = plt.subplots()
+    ax = heputils.plot.stack_hist(
+        hists,
+        xlabel="test_label",
+        ylabel="Count",
+        ax=ax,
+    )
+    assert ax.get_xlabel() == "test_label"
+    ax = heputils.plot.data_hist(hist_3, ax=ax)
+    assert ax.get_xlabel() == "test_label"

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -48,3 +48,44 @@ def test_data_hist_xlabel_passed_through_ax(hist_tuple):
     assert ax.get_xlabel() == "test_label"
     ax = heputils.plot.data_hist(hist_3, ax=ax)
     assert ax.get_xlabel() == "test_label"
+
+
+def test_shape_hist_xlabel_passed_through_ax(hist_tuple):
+    np.random.seed(0)
+    heputils.plot.set_style("ATLAS")
+
+    hists = list(hist_tuple[:2])
+    hist_3 = hist_tuple[-1]
+
+    fig, ax = plt.subplots()
+    ax = heputils.plot.stack_hist(
+        hists,
+        xlabel="test_label",
+        ylabel="Count",
+        ax=ax,
+    )
+    assert ax.get_xlabel() == "test_label"
+    ax = heputils.plot.shape_hist(hist_3, ax=ax)
+    assert ax.get_xlabel() == "test_label"
+
+
+def test_stack_hist_xlabel_passed_through_ax(hist_tuple):
+    np.random.seed(0)
+    heputils.plot.set_style("ATLAS")
+
+    hists = list(hist_tuple[:2])
+    hist_3 = hist_tuple[-1]
+
+    fig, ax = plt.subplots()
+    ax = heputils.plot.data_hist(
+        hist_3,
+        xlabel="test_label",
+        ylabel="Count",
+        ax=ax,
+    )
+    assert ax.get_xlabel() == "test_label"
+    ax = heputils.plot.stack_hist(
+        hists,
+        ax=ax,
+    )
+    assert ax.get_xlabel() == "test_label"

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,6 +1,4 @@
 import hist
-
-# from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 import numpy as np
 from hist import Hist

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,15 +1,14 @@
 import hist
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 from hist import Hist
 
 import heputils
 
 
-def test_xlabel_passed_through_ax():
-    np.random.seed(0)
-    heputils.plot.set_style("ATLAS")
-
+@pytest.fixture
+def hist_tuple():
     hist_1 = Hist(
         hist.axis.Regular(
             50, -5, 5, name="x", label="x [units]", underflow=False, overflow=False
@@ -29,7 +28,15 @@ def test_xlabel_passed_through_ax():
         storage=hist.storage.Weight(),
     ).fill(np.random.normal(size=1000), weight=1.0)
 
-    hists = [hist_1, hist_2]
+    return hist_1, hist_2, hist_3
+
+
+def test_data_hist_xlabel_passed_through_ax(hist_tuple):
+    np.random.seed(0)
+    heputils.plot.set_style("ATLAS")
+
+    hists = list(hist_tuple[:2])
+    hist_3 = hist_tuple[-1]
 
     fig, ax = plt.subplots()
     ax = heputils.plot.stack_hist(

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,10 +1,13 @@
 import hist
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from hist import Hist
 
 import heputils
+
+matplotlib.use("agg")
 
 
 @pytest.fixture


### PR DESCRIPTION
Resolves #68 (Thanks @andrzejnovak and @alexander-held for the help on thinking about this)

```
* If a matplotlib.axes.Axes object is passed through the ax kwarg, set the xlabel kwarg from it if unset to ensure that the previous plot's xlabel is preserved
* Add test for xlabel being passed through with ax
```