### PR TITLE
fix: Apply scale factors to the ratio plot in `stack_ratio_plot`

### DIFF
--- a/examples/dev-example.ipynb
+++ b/examples/dev-example.ipynb
@@ -283,7 +283,7 @@
     "    data_hist=data_hist,\n",
     "    labels=labels,\n",
     "    color=colormap,\n",
-    "    rp_ylim=[-1, 12],\n",
+    "    rp_ylim=[-1, 8],\n",
     "    xlabel=r\"$X$ Mass [GeV]\",\n",
     "    ylabel=\"Count\",\n",
     "    logy=False,\n",

--- a/src/heputils/plot.py
+++ b/src/heputils/plot.py
@@ -549,7 +549,14 @@ def stack_ratio_plot(hists, **kwargs):
         "rp_uncert_draw_type": kwargs.pop("rp_uncert_draw_type", "line"),
     }
 
-    num_hists = utils.sum_hists(hists)
+    # .get not .pop to pass scale_factors through to stack_hist too
+    scale_factors = kwargs.get("scale_factors", None)
+    num_hists = (
+        utils.sum_hists(hists)
+        if scale_factors is None
+        else utils.sum_hists([h * sf for h, sf in zip(hists, scale_factors)])
+    )
+
     if ratio_plot_numerator.lower() in ["simulation", "sim", "mc"]:
         ratio_plot_kwargs["rp_ylabel"] = kwargs.pop("rp_ylabel", "MC/Data")
         num_hists.plot_ratio(_data_hist, **ratio_plot_kwargs)


### PR DESCRIPTION
Resolves #76 

```
* If `stack_ratio_plot` is given a `scale_factors` kwarg apply the scale factors to both the main plot as well as to the ratio plot
* In the dev-notebook reduce the rp_ylim for the stack_ratio_plot example to focus more
```