### PR TITLE
docs: Change Binder launch URL given mybinder.org change to JupyterLab as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Code Coverage](https://codecov.io/gh/matthewfeickert/heputils/graph/badge.svg?branch=main)](https://codecov.io/gh/matthewfeickert/heputils?branch=main)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/matthewfeickert/heputils/main.svg)](https://results.pre-commit.ci/latest/github/matthewfeickert/heputils/main)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/heputils/HEAD?urlpath=lab/tree/examples/dev-example.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/heputils/HEAD)
 
 [![PyPI version](https://badge.fury.io/py/heputils.svg)](https://badge.fury.io/py/heputils)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/heputils.svg)](https://pypi.org/project/heputils/)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Code Coverage](https://codecov.io/gh/matthewfeickert/heputils/graph/badge.svg?branch=main)](https://codecov.io/gh/matthewfeickert/heputils?branch=main)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/matthewfeickert/heputils/main.svg)](https://results.pre-commit.ci/latest/github/matthewfeickert/heputils/main)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/heputils/HEAD?filepath=examples%2Fdev-example.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/heputils/HEAD?filepath=examples/dev-example.ipynb)
 
 [![PyPI version](https://badge.fury.io/py/heputils.svg)](https://badge.fury.io/py/heputils)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/heputils.svg)](https://pypi.org/project/heputils/)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Code Coverage](https://codecov.io/gh/matthewfeickert/heputils/graph/badge.svg?branch=main)](https://codecov.io/gh/matthewfeickert/heputils?branch=main)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/matthewfeickert/heputils/main.svg)](https://results.pre-commit.ci/latest/github/matthewfeickert/heputils/main)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/heputils/HEAD)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/heputils/HEAD?filepath=examples%2Fdev-example.ipynb)
 
 [![PyPI version](https://badge.fury.io/py/heputils.svg)](https://badge.fury.io/py/heputils)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/heputils.svg)](https://pypi.org/project/heputils/)


### PR DESCRIPTION
Binder now launches into JupyterLab by default.

c.f.
- https://twitter.com/betatim/status/1437356213256208384
- https://blog.ouseful.info/2021/09/13/the-world-moves-on-jupyter-classic-notebook-no-longer-the-mybinder-default-ui/
- https://discourse.jupyter.org/t/mybinder-org-using-jupyterlab-by-default/10715


[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/heputils/HEAD?filepath=examples/dev-example.ipynb)

```
* Change Binder launch URL to default as mybinder.org now launches into JupyterLab by default
   - https://discourse.jupyter.org/t/mybinder-org-using-jupyterlab-by-default/10715
   - https://blog.ouseful.info/2021/09/13/the-world-moves-on-jupyter-classic-notebook-no-longer-the-mybinder-default-ui/
```